### PR TITLE
Update CMake action to use latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Setup CMake (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        uses: lukka/get-cmake@v3
+        uses: lukka/get-cmake@latest
 
       - name: Setup MSVC dev environment (Windows)
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
This pull request updates the CMake setup step in the CI workflow to use the latest version of the `lukka/get-cmake` GitHub Action for Ubuntu builds. This ensures the CI pipeline always uses the most up-to-date version of CMake.

CI workflow improvement:

* Updated the CMake setup step in `.github/workflows/ci.yml` to use `lukka/get-cmake@latest` instead of a specific version (`v3`) for Ubuntu builds.